### PR TITLE
Remove unused js reference in clientlibs

### DIFF
--- a/src/main/content/jcr_root/etc/clientlibs/groovyconsole/js.txt
+++ b/src/main/content/jcr_root/etc/clientlibs/groovyconsole/js.txt
@@ -21,7 +21,6 @@ theme-github.js
 theme-idle_fingers.js
 theme-katzenmilch.js
 theme-kr.js
-theme-kr_theme.js
 theme-kuroir.js
 theme-merbivore.js
 theme-merbivore_soft.js


### PR DESCRIPTION
Caused warning on package installation:
com.adobe.granite.ui.clientlibs.impl.FileBundle Referenced path in /etc/groovyconsole/clientlibs/js.txt does not exist: /etc/groovyconsole/clientlibs/js/theme-kr_theme.js