### PR TITLE
Set dependency on the cq-content package 

### DIFF
--- a/src/main/content/META-INF/vault/properties.xml
+++ b/src/main/content/META-INF/vault/properties.xml
@@ -12,7 +12,7 @@
     <entry key="buildCount">1</entry>
     <entry key="version">${project.version}</entry>
     <entry key="requiresRoot">true</entry>
-    <entry key="dependencies" />
+    <entry key="dependencies">day/cq60/product:cq-content:6.3.64</entry>
     <entry key="group">ICF Olson</entry>
     <entry key="packageFormatVersion">2</entry>
     <entry key="lastWrapped">${timestamp}</entry>


### PR DESCRIPTION
Set dependency on the cq-content package as to make sure the cq primary types (like cq:Component) are available on installation of this package

fixes #67