### PR TITLE
Show output up to the point when an error is thrown.

### DIFF
--- a/src/main/content/jcr_root/apps/groovyconsole/components/console/body.html
+++ b/src/main/content/jcr_root/apps/groovyconsole/components/console/body.html
@@ -17,8 +17,6 @@
 
     <div id="script-editor" class="ace_editor_wrapper"></div>
 
-    <pre id="stacktrace" class="alert-danger" style="display: none;"></pre>
-
     <div id="result" class="alert alert-success" role="alert" style="display: none;">
         <h6>Result</h6>
         <pre></pre>
@@ -37,6 +35,8 @@
         <h6>Output</h6>
         <pre></pre>
     </div>
+
+    <pre id="stacktrace" class="alert-danger" style="display: none;"></pre>
 
     <div id="running-time" class="alert alert-info" role="alert" style="display: none;">
         <h6>Running Time</h6>

--- a/src/main/content/jcr_root/etc/clientlibs/groovyconsole/js/console.js
+++ b/src/main/content/jcr_root/etc/clientlibs/groovyconsole/js/console.js
@@ -220,6 +220,12 @@ var GroovyConsole = function () {
             var runningTime = response.runningTime;
 
             if (exceptionStackTrace && exceptionStackTrace.length) {
+                if (output && output.length) {
+                    $('#output pre').text(output);
+                    $('#output').removeClass('alert-success')
+                        .addClass('alert-danger')
+                        .fadeIn('fast');
+                }
                 $('#stacktrace').text(exceptionStackTrace).fadeIn('fast');
             } else {
                 if (!GroovyConsole.showTable(response) && result && result.length) {
@@ -229,7 +235,9 @@ var GroovyConsole = function () {
 
                 if (output && output.length) {
                     $('#output pre').text(output);
-                    $('#output').fadeIn('fast');
+                    $('#output').removeClass('alert-danger')
+                        .addClass('alert-success')
+                        .fadeIn('fast');
                 }
 
                 if (runningTime && runningTime.length) {

--- a/src/main/groovy/com/icfolson/aem/groovy/console/audit/impl/DefaultAuditService.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/audit/impl/DefaultAuditService.groovy
@@ -214,6 +214,10 @@ class DefaultAuditService implements AuditService {
 
         if (response.exceptionStackTrace) {
             auditRecordNode.setProperty(AuditRecord.PROPERTY_EXCEPTION_STACK_TRACE, response.exceptionStackTrace)
+
+            if (response.output) {
+                auditRecordNode.setProperty(AuditRecord.PROPERTY_OUTPUT, response.output)
+            }
         } else {
             if (response.result) {
                 auditRecordNode.setProperty(AuditRecord.PROPERTY_RESULT, response.result)

--- a/src/main/groovy/com/icfolson/aem/groovy/console/impl/DefaultGroovyConsoleService.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/impl/DefaultGroovyConsoleService.groovy
@@ -121,11 +121,11 @@ class DefaultGroovyConsoleService implements GroovyConsoleService {
         } catch (MultipleCompilationErrorsException e) {
             LOG.error("script compilation error", e)
 
-            response = RunScriptResponse.fromException(scriptContent, e)
+            response = RunScriptResponse.fromException(scriptContent, stream.toString(CharEncoding.UTF_8), e)
         } catch (Throwable t) {
             LOG.error("error running script", t)
 
-            response = RunScriptResponse.fromException(scriptContent, t)
+            response = RunScriptResponse.fromException(scriptContent, stream.toString(CharEncoding.UTF_8), t)
 
             auditAndNotify(session, response)
         } finally {

--- a/src/main/groovy/com/icfolson/aem/groovy/console/notification/impl/EmailNotificationService.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/notification/impl/EmailNotificationService.groovy
@@ -85,7 +85,10 @@ class EmailNotificationService implements NotificationService {
         ]
 
         if (response.exceptionStackTrace) {
-            binding.stackTrace = response.exceptionStackTrace
+            binding.putAll([
+                stackTrace: response.exceptionStackTrace,
+                output: response.output
+            ])
         } else {
             binding.putAll([
                 result: response.result,

--- a/src/main/groovy/com/icfolson/aem/groovy/console/response/RunScriptResponse.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/response/RunScriptResponse.groovy
@@ -26,10 +26,10 @@ class RunScriptResponse {
         new RunScriptResponse(script, data, resultString, output, "", runningTime)
     }
 
-    static RunScriptResponse fromException(String script, Throwable throwable) {
+    static RunScriptResponse fromException(String script, String output, Throwable throwable) {
         def exceptionStackTrace = ExceptionUtils.getStackTrace(throwable)
 
-        new RunScriptResponse(script, "", "", "", exceptionStackTrace, "")
+        new RunScriptResponse(script, "", "", output, exceptionStackTrace, "")
     }
 
     static RunScriptResponse fromAuditRecordResource(Resource resource) {
@@ -38,14 +38,14 @@ class RunScriptResponse {
         def script = properties.get(PROPERTY_SCRIPT, "")
         def data = properties.get(PROPERTY_DATA, "")
         def exceptionStackTrace = properties.get(PROPERTY_EXCEPTION_STACK_TRACE, "")
+        def output = properties.get(AuditRecord.PROPERTY_OUTPUT, "")
 
         def response
 
         if (exceptionStackTrace) {
-            response = new RunScriptResponse(script, data, "", "", exceptionStackTrace, "")
+            response = new RunScriptResponse(script, data, "", output, exceptionStackTrace, "")
         } else {
             def result = properties.get(AuditRecord.PROPERTY_RESULT, "")
-            def output = properties.get(AuditRecord.PROPERTY_OUTPUT, "")
             def runningTime = properties.get(AuditRecord.PROPERTY_RUNNING_TIME, "")
 
             response = new RunScriptResponse(script, data, result, output, "", runningTime)

--- a/src/test/groovy/com/icfolson/aem/groovy/console/audit/impl/DefaultAuditServiceSpec.groovy
+++ b/src/test/groovy/com/icfolson/aem/groovy/console/audit/impl/DefaultAuditServiceSpec.groovy
@@ -53,7 +53,7 @@ class DefaultAuditServiceSpec extends ProsperSpec {
     def "create audit record for script with exception"() {
         when:
         def exception = new RuntimeException("")
-        def response = RunScriptResponse.fromException("script content", exception)
+        def response = RunScriptResponse.fromException("script content", "output", exception)
         def auditRecord = auditService.createAuditRecord(session, response)
 
         then:
@@ -61,6 +61,7 @@ class DefaultAuditServiceSpec extends ProsperSpec {
 
         and:
         auditRecord.script == "script content"
+        auditRecord.output == "output"
         auditRecord.exceptionStackTrace == ExceptionUtils.getStackTrace(exception)
     }
 


### PR DESCRIPTION
This is extremely helpful when troubleshooting problems with a script. Currently, you get no output, and just the stacktrace. This shows any output that has been captured, up to when the exception was thrown.

1. Output is displayed first (before stacktrace)
2. Output is stored for audit records
3. Output is retrieved for audit records
4. Output is available in error emails