### PR TITLE
HTML descriptions for binding providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <groupId>com.icfolson.aem.groovy.console</groupId>
     <artifactId>aem-groovy-console</artifactId>
     <packaging>jar</packaging>
-    <version>12.1.1-SNAPSHOT</version>
+    <version>12.1.2-SNAPSHOT</version>
     <name>AEM Groovy Console</name>
     <description>
         The AEM Groovy Console provides an interface for running Groovy scripts in the AEM container. Scripts can be

--- a/src/main/content/jcr_root/apps/groovyconsole/components/console/bindings.html
+++ b/src/main/content/jcr_root/apps/groovyconsole/components/console/bindings.html
@@ -5,9 +5,9 @@
         </h4>
     </div>
     <div id="bindings" class="panel-collapse collapse">
-        <div class="panel-body" data-sly-use.bindings="com.icfolson.aem.groovy.console.components.Bindings">
+        <div class="panel-body" data-sly-use.bindingsInfo="com.icfolson.aem.groovy.console.components.BindingsInfo">
             <p>The binding variables listed below are available for use in all scripts.</p>
-            ${bindings.description @ context='html'}
+            ${bindingsInfo.description @ context='html'}
         </div>
     </div>
 </div>

--- a/src/main/content/jcr_root/apps/groovyconsole/components/console/bindings.html
+++ b/src/main/content/jcr_root/apps/groovyconsole/components/console/bindings.html
@@ -5,17 +5,9 @@
         </h4>
     </div>
     <div id="bindings" class="panel-collapse collapse">
-        <div class="panel-body">
+        <div class="panel-body" data-sly-use.bindings="com.icfolson.aem.groovy.console.components.Bindings">
             <p>The binding variables listed below are available for use in all scripts.</p>
-            <ul>
-                <li>session - <a href="https://docs.adobe.com/docs/en/spec/javax.jcr/javadocs/jcr-2.0/javax/jcr/Session.html" target="_blank">javax.jcr.Session</a></li>
-                <li>pageManager - com.day.cq.wcm.api.PageManager</li>
-                <li>resourceResolver - <a href="https://sling.apache.org/apidocs/sling10/org/apache/sling/api/resource/ResourceResolver.html" target="_blank">org.apache.sling.api.resource.ResourceResolver</a></li>
-                <li>slingRequest - <a href="https://sling.apache.org/apidocs/sling10/org/apache/sling/api/SlingHttpServletRequest.html" target="_blank">org.apache.sling.api.SlingHttpServletRequest</a></li>
-                <li>queryBuilder - <a href="https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/javadoc/com/day/cq/search/QueryBuilder.html" target="_blank">com.day.cq.search.QueryBuilder</a></li>
-                <li>bundleContext - <a href="http://www.osgi.org/javadoc/r4v43/core/org/osgi/framework/BundleContext.html" target="_blank">org.osgi.framework.BundleContext</a></li>
-                <li>log - <a href="http://www.slf4j.org/api/org/slf4j/Logger.html" target="_blank">org.slf4j.Logger</a></li>
-            </ul>
+            ${bindings.description @ context='html'}
         </div>
     </div>
 </div>

--- a/src/main/content/jcr_root/apps/groovyconsole/components/console/defaultbindings.html
+++ b/src/main/content/jcr_root/apps/groovyconsole/components/console/defaultbindings.html
@@ -1,0 +1,23 @@
+<ul>
+  <li>session -
+    <a href="http://www.day.com/maven/jsr170/javadocs/jcr-2.0/javax/jcr/Session.html" target="_blank">javax.jcr.Session</a>
+  </li>
+  <li>pageManager -
+    <a href="http://dev.day.com/content/docs/en/cq/current/javadoc/com/day/cq/wcm/api/PageManager.html" target="_blank">com.day.cq.wcm.api.PageManager</a>
+  </li>
+  <li>resourceResolver -
+    <a href="http://sling.apache.org/apidocs/sling5/org/apache/sling/api/resource/ResourceResolver.html" target="_blank">org.apache.sling.api.resource.ResourceResolver</a>
+  </li>
+  <li>slingRequest -
+    <a href="http://sling.apache.org/apidocs/sling5/org/apache/sling/api/SlingHttpServletRequest.html" target="_blank">org.apache.sling.api.SlingHttpServletRequest</a>
+  </li>
+  <li>queryBuilder -
+    <a href="http://dev.day.com/docs/en/cq/current/javadoc/com/day/cq/search/QueryBuilder.html" target="_blank">com.day.cq.search.QueryBuilder</a>
+  </li>
+  <li>bundleContext -
+    <a href="http://www.osgi.org/javadoc/r4v43/core/org/osgi/framework/BundleContext.html" target="_blank">org.osgi.framework.BundleContext</a>
+  </li>
+  <li>log -
+    <a href="http://www.slf4j.org/api/org/slf4j/Logger.html" target="_blank">org.slf4j.Logger</a>
+  </li>
+</ul>

--- a/src/main/groovy/com/icfolson/aem/groovy/console/api/BindingExtensionProvider.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/api/BindingExtensionProvider.groovy
@@ -1,11 +1,13 @@
 package com.icfolson.aem.groovy.console.api
 
+import org.apache.commons.lang3.CharEncoding
 import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.resource.Resource
 
 /**
  * Services may implement this interface to supply additional binding values for Groovy script executions.
  */
-interface BindingExtensionProvider {
+trait BindingExtensionProvider {
 
     /**
      * Get the binding for this request.  All bindings provided by extension services will be merged prior to script
@@ -14,5 +16,25 @@ interface BindingExtensionProvider {
      * @param request current request
      * @return binding map for request
      */
-    Binding getBinding(SlingHttpServletRequest request)
+    abstract Binding getBinding(SlingHttpServletRequest request)
+
+    /**
+     * Get the description html for this binding provider bindings
+     *
+     */
+    String getBindingDescription(SlingHttpServletRequest request) {
+        String filePath = this.bindingDescriptionFilePath
+        String description = null
+
+        if (filePath) {
+            Resource fileResource = request.resourceResolver.getResource(filePath)
+            description = fileResource?.adaptTo(InputStream)?.getText(CharEncoding.UTF_8)
+        }
+
+        description
+    }
+
+    String getBindingDescriptionFilePath() {
+        null
+    }
 }

--- a/src/main/groovy/com/icfolson/aem/groovy/console/components/Bindings.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/components/Bindings.groovy
@@ -1,0 +1,23 @@
+package com.icfolson.aem.groovy.console.components
+
+import com.icfolson.aem.groovy.console.extension.ExtensionService
+import org.apache.sling.api.SlingHttpServletRequest
+import org.apache.sling.api.resource.Resource
+import org.apache.sling.models.annotations.Model
+
+
+import javax.inject.Inject
+
+@Model(adaptables = SlingHttpServletRequest)
+class Bindings {
+
+    @Inject
+    private SlingHttpServletRequest request
+
+    @Inject
+    private ExtensionService extensionService
+
+    String getDescription() {
+      extensionService.getBindingDescription(request)
+    }
+}

--- a/src/main/groovy/com/icfolson/aem/groovy/console/components/BindingsInfo.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/components/BindingsInfo.groovy
@@ -9,7 +9,7 @@ import org.apache.sling.models.annotations.Model
 import javax.inject.Inject
 
 @Model(adaptables = SlingHttpServletRequest)
-class Bindings {
+class BindingsInfo {
 
     @Inject
     private SlingHttpServletRequest request

--- a/src/main/groovy/com/icfolson/aem/groovy/console/extension/impl/DefaultBindingExtensionProvider.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/extension/impl/DefaultBindingExtensionProvider.groovy
@@ -42,6 +42,10 @@ class DefaultBindingExtensionProvider implements BindingExtensionProvider {
         ])
     }
 
+    String getBindingDescriptionFilePath() {
+        return '/apps/groovyconsole/components/console/defaultbindings.html'
+    }
+
     @Activate
     void activate(BundleContext bundleContext) {
         this.bundleContext = bundleContext

--- a/src/main/groovy/com/icfolson/aem/groovy/console/extension/impl/DefaultExtensionService.groovy
+++ b/src/main/groovy/com/icfolson/aem/groovy/console/extension/impl/DefaultExtensionService.groovy
@@ -58,6 +58,17 @@ class DefaultExtensionService implements ExtensionService {
     }
 
     @Override
+    String getBindingDescription(SlingHttpServletRequest request) {
+        bindingExtensionProviders.findResults { extension ->
+            extension.getBindingDescription(request)
+        }.collect { description ->
+            "<div>${description}</div>"
+        }.inject("") { combinedDescription, description ->
+            "${combinedDescription}${description}"
+        }
+    }
+
+    @Override
     List<Closure> getScriptMetaClasses(SlingHttpServletRequest request) {
         scriptMetaClassExtensionProviders*.getScriptMetaClass(request)
     }

--- a/src/test/groovy/com/icfolson/aem/groovy/console/services/impl/DefaultExtensionServiceSpec.groovy
+++ b/src/test/groovy/com/icfolson/aem/groovy/console/services/impl/DefaultExtensionServiceSpec.groovy
@@ -40,6 +40,10 @@ class DefaultExtensionServiceSpec extends ProsperSpec {
                 selectors: []
             ])
         }
+
+        String getBindingDescription(SlingHttpServletRequest request) {
+            "first"
+        }
     }
 
     class SecondBindingExtensionProvider implements BindingExtensionProvider {
@@ -50,6 +54,10 @@ class DefaultExtensionServiceSpec extends ProsperSpec {
                 path: request.requestPathInfo.resourcePath,
                 selectors: request.requestPathInfo.selectors as List
             ])
+        }
+
+        String getBindingDescription(SlingHttpServletRequest request) {
+            "second"
         }
     }
 
@@ -106,12 +114,14 @@ class DefaultExtensionServiceSpec extends ProsperSpec {
         extensionService.getBinding(request)["selectors"] == request.requestPathInfo.selectors as List
         extensionService.getBinding(request)["parameterNames"] == request.parameterMap.keySet()
         extensionService.getBinding(request)["path"] == "/"
+        extensionService.getBindingDescription(request) == "<div>first</div><div>second</div>"
 
         when:
         extensionService.unbindBindingExtensionProvider(secondProvider)
 
         then:
         extensionService.getBinding(request)["selectors"] == []
+        extensionService.getBindingDescription(request) == "<div>first</div>"
 
         when:
         extensionService.getBinding(request)["path"]


### PR DESCRIPTION
Allows a `BindingExtensionProvider` to also provide a text or html text description, to be included on the console page.

Support for #75.

Also, a back port for the 11.X.X version provided in https://github.com/paul-bjorkstrand/cq-groovy-console/tree/feature/custom-binding-description-11.X.X